### PR TITLE
Updates the CSS class to the most recent version

### DIFF
--- a/nupkg-cli.py
+++ b/nupkg-cli.py
@@ -23,7 +23,7 @@ class NupkgHTMLParser (HTMLParser):
 
         if tag == 'ul':
             attrsDict = dict(attrs)
-            if 'class' in attrsDict and attrsDict['class'] == 'dependencySet':
+            if 'class' in attrsDict and attrsDict['class'] == 'list-unstyled dependency-groups':
                 self.dependenciesInTracking = True
 
     def handle_endtag(self, tag):


### PR DESCRIPTION
It looks like nuget.org have altered the CSS on their website. I adapted the CSS class to something which finds the dependencies section, it might not do exactly what was done before, though. For my case, this fix worked.